### PR TITLE
Use mutation probability by locus for mutations

### DIFF
--- a/input/input.yml
+++ b/input/input.yml
@@ -469,6 +469,10 @@ initial_parasite_info:
 #       - set k=2 or k=4 for a piecewise-linear model where mutation probability increases from high concentrations
 #               to intermediate concentrations, and then decreases linearly from intermediate concentrations to zero
 #
+
+# this is the daily probability that a parasite will mutate at a given locus when the drug concentration is not zero
+mutation_probability_by_locus: 0.005
+
 drug_db:
   0:
     name: "artemisinin"
@@ -476,7 +480,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.999
     n: 25
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.75
   1:
@@ -486,7 +489,6 @@ drug_db:
     n: 20
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
     age_specific_drug_absorption: [ 0.7,0.7,0.85,0.85,0.85,0.85,0.85,0.85,0.85,0.85,1.0,1.0,1.0,1.0,1.0 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.6
   2:
@@ -495,7 +497,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.95
     n: 19
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.5
   3:
@@ -504,7 +505,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.9
     n: 15
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.58
   #MQ
@@ -514,7 +514,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.9
     n: 15
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.45
     resistant_genes: [ "Pfmdr1" ]
@@ -524,7 +523,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.9
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
     n: 15
-    mutation_probability: 0.000
     k: 4
     base_EC50: 1.08
     resistant_genes: [ ]
@@ -534,7 +532,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.95
     n: 19
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.72
   7:
@@ -543,7 +540,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.99
     n: 15
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.55
 

--- a/input/input.yml
+++ b/input/input.yml
@@ -188,7 +188,7 @@ circulation_info:
     mean: 5
     sd: 10
 
-mutation_mask: "||||111||11111,0||||||0000001001|1"
+mutation_mask: "||||111||11111,0||||||000000010010|1"
 
 # the appearance of gene should be in order
 pf_genotype_info:
@@ -291,6 +291,12 @@ pf_genotype_info:
             multiplicative_effect_on_EC50:
               - drug_id: 0
                 factors: [ 1, 1.6 ]
+          - position: 469
+            amino_acids: [ 'C', 'Y' ]
+            daily_crs: [ 0, 0.0005 ]
+            multiplicative_effect_on_EC50:
+              - drug_id: 0
+                factors: [ 1, 1.6 ]
           - position: 476
             amino_acids: [ 'M', 'I' ]
             daily_crs: [ 0, 0.0005 ]
@@ -339,6 +345,12 @@ pf_genotype_info:
             multiplicative_effect_on_EC50:
               - drug_id: 0
                 factors: [ 1, 1.6 ]
+          - position: 675
+            amino_acids: [ 'A', 'V' ]
+            daily_crs: [ 0, 0.0005 ]
+            multiplicative_effect_on_EC50:
+              - drug_id: 0
+                factors: [ 1, 1.6 ]
   - chromosome: 14
     genes:
       - name: "Pfplasmepsin"
@@ -350,76 +362,76 @@ pf_genotype_info:
         aa_positions: [ ]
 
 override_ec50_patterns:
-  - pattern: "||||NY1||K....,.||||||..........|."
+  - pattern: "||||NY1||K....,.||||||............|."
     drug_id: 1
     ec50: 0.8
-  - pattern: "||||YY1||K....,.||||||..........|."
+  - pattern: "||||YY1||K....,.||||||............|."
     drug_id: 1
     ec50: 0.67
-  - pattern: "||||NF1||K....,.||||||..........|."
+  - pattern: "||||NF1||K....,.||||||............|."
     drug_id: 1
     ec50: 0.9
-  - pattern: "||||YF1||K....,.||||||..........|."
+  - pattern: "||||YF1||K....,.||||||............|."
     drug_id: 1
     ec50: 0.8
-  - pattern: "||||NY2||K....,.||||||..........|."
+  - pattern: "||||NY2||K....,.||||||............|."
     drug_id: 1
     ec50: 1.0
-  - pattern: "||||YY2||K....,.||||||..........|."
+  - pattern: "||||YY2||K....,.||||||............|."
     drug_id: 1
     ec50: 0.87
-  - pattern: "||||NF2||K....,.||||||..........|."
+  - pattern: "||||NF2||K....,.||||||............|."
     drug_id: 1
     ec50: 1.1
-  - pattern: "||||YF2||K....,.||||||..........|."
+  - pattern: "||||YF2||K....,.||||||............|."
     drug_id: 1
     ec50: 1.0
-  - pattern: "||||NY1||T....,.||||||..........|."
+  - pattern: "||||NY1||T....,.||||||............|."
     drug_id: 1
     ec50: 0.75
-  - pattern: "||||YY1||T....,.||||||..........|."
+  - pattern: "||||YY1||T....,.||||||............|."
     drug_id: 1
     ec50: 0.6
-  - pattern: "||||NF1||T....,.||||||..........|."
+  - pattern: "||||NF1||T....,.||||||............|."
     drug_id: 1
     ec50: 0.85
-  - pattern: "||||YF1||T....,.||||||..........|."
+  - pattern: "||||YF1||T....,.||||||............|."
     drug_id: 1
     ec50: 0.75
-  - pattern: "||||NY2||T....,.||||||..........|."
+  - pattern: "||||NY2||T....,.||||||............|."
     drug_id: 1
     ec50: 0.95
-  - pattern: "||||YY2||T....,.||||||..........|."
+  - pattern: "||||YY2||T....,.||||||............|."
     drug_id: 1
     ec50: 0.8
-  - pattern: "||||NF2||T....,.||||||..........|."
+  - pattern: "||||NF2||T....,.||||||............|."
     drug_id: 1
     ec50: 1.05
-  - pattern: "||||YF2||T....,.||||||..........|."
+  - pattern: "||||YF2||T....,.||||||............|."
     drug_id: 1
     ec50: 0.95
-  - pattern: "||||NY.||K....,.||||||..........|."
+  - pattern: "||||NY.||K....,.||||||............|."
     drug_id: 2
     ec50: 0.62
-  - pattern: "||||YY.||K....,.||||||..........|."
+  - pattern: "||||YY.||K....,.||||||............|."
     drug_id: 2
     ec50: 0.85
-  - pattern: "||||NF.||K....,.||||||..........|."
+  - pattern: "||||NF.||K....,.||||||............|."
     drug_id: 2
     ec50: 0.5
-  - pattern: "||||YF.||K....,.||||||..........|."
+  - pattern: "||||YF.||K....,.||||||............|."
     drug_id: 2
     ec50: 0.775
-  - pattern: "||||NY.||T....,.||||||..........|."
+  - pattern: "||||NY.||T....,.||||||............|."
     drug_id: 2
     ec50: 0.7
-  - pattern: "||||YY.||T....,.||||||..........|."
+  - pattern: "||||YY.||T....,.||||||............|."
     drug_id: 2
     ec50: 0.9
-  - pattern: "||||NF.||T....,.||||||..........|."
+  - pattern: "||||NF.||T....,.||||||............|."
     drug_id: 2
     ec50: 0.65
-  - pattern: "||||YF.||T....,.||||||..........|."
+  - pattern: "||||YF.||T....,.||||||............|."
     drug_id: 2
     ec50: 0.82
 
@@ -430,9 +442,9 @@ initial_parasite_info:
   - location_id: -1
     parasite_info:
       #TNY__C1x
-      - aa_sequence: "||||NY1||KTHFI,x||||||FNMYRIPRPC|1"
+      - aa_sequence: "||||NY1||KTHFI,x||||||FNCMYRIPRPCA|1"
         prevalence: 0.05
-      - aa_sequence: "||||YY1||KTHFI,x||||||FNMYRIPRPC|1"
+      - aa_sequence: "||||NY1||KTHFI,x||||||FNCMYRIPRPCA|1"
         prevalence: 0.05
 
 # drug information below
@@ -741,7 +753,7 @@ min_dosing_days: 1
 # exponentially distributed biting rate
 relative_bitting_info:
   max_relative_biting_value: 35
-  min_relative_biting_value: 0.35
+  min_relative_biting_value: 1.0
   number_of_biting_levels: 100
   biting_level_distribution:
     #  distribution: Exponential
@@ -940,6 +952,6 @@ sd_prob_individual_present_at_mda: [ 0.3, 0.3, 0.3 ]
 #Mosquito
 mosquito_config:
   interrupted_feeding_rate: [0.19]
-  prmc_size: 40
+  prmc_size: 120
 
 within_host_induced_free_recombination: true

--- a/input/input_simple.yml
+++ b/input/input_simple.yml
@@ -454,6 +454,10 @@ initial_parasite_info:
 #       - set k=2 or k=4 for a piecewise-linear model where mutation probability increases from high concentrations
 #               to intermediate concentrations, and then decreases linearly from intermediate concentrations to zero
 #
+
+# this is the daily probability that a parasite will mutate at a given locus when the drug concentration is not zero
+mutation_probability_by_locus: 0.005
+
 drug_db:
   0:
     name: "artemisinin"
@@ -461,7 +465,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.999
     n: 25
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.75
   1:
@@ -471,7 +474,6 @@ drug_db:
     n: 20
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
     age_specific_drug_absorption: [ 0.7,0.7,0.85,0.85,0.85,0.85,0.85,0.85,0.85,0.85,1.0,1.0,1.0,1.0,1.0 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.6
   2:
@@ -480,7 +482,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.95
     n: 19
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.5
   3:
@@ -489,7 +490,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.9
     n: 15
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.58
   #MQ
@@ -499,7 +499,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.9
     n: 15
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.45
     resistant_genes: [ "Pfmdr1" ]
@@ -509,7 +508,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.9
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
     n: 15
-    mutation_probability: 0.000
     k: 4
     base_EC50: 1.08
     resistant_genes: [ ]
@@ -519,7 +517,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.95
     n: 19
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.72
   7:
@@ -528,7 +525,6 @@ drug_db:
     maximum_parasite_killing_rate: 0.99
     n: 15
     age_specific_drug_concentration_sd: [ 0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4,0.4 ]
-    mutation_probability: 0.005
     k: 4
     base_EC50: 0.55
 

--- a/input/input_simple.yml
+++ b/input/input_simple.yml
@@ -173,8 +173,7 @@ circulation_info:
     mean: 5
     sd: 10
 
-mutation_mask: "||||111||11111,0||||||0000001001|1"
-# mutation_mask: "||||000||00000,0||||||0000000000|0"
+mutation_mask: "||||111||11111,0||||||000000010010|1"
 
 # the appearance of gene should be in order
 pf_genotype_info:
@@ -277,6 +276,12 @@ pf_genotype_info:
             multiplicative_effect_on_EC50:
               - drug_id: 0
                 factors: [ 1, 1.6 ]
+          - position: 469
+            amino_acids: [ 'C', 'Y' ]
+            daily_crs: [ 0, 0.0005 ]
+            multiplicative_effect_on_EC50:
+              - drug_id: 0
+                factors: [ 1, 1.6 ]
           - position: 476
             amino_acids: [ 'M', 'I' ]
             daily_crs: [ 0, 0.0005 ]
@@ -325,6 +330,12 @@ pf_genotype_info:
             multiplicative_effect_on_EC50:
               - drug_id: 0
                 factors: [ 1, 1.6 ]
+          - position: 675
+            amino_acids: [ 'A', 'V' ]
+            daily_crs: [ 0, 0.0005 ]
+            multiplicative_effect_on_EC50:
+              - drug_id: 0
+                factors: [ 1, 1.6 ]
   - chromosome: 14
     genes:
       - name: "Pfplasmepsin"
@@ -336,76 +347,76 @@ pf_genotype_info:
         aa_positions: [ ]
 
 override_ec50_patterns:
-  - pattern: "||||NY1||K....,.||||||..........|."
+  - pattern: "||||NY1||K....,.||||||............|."
     drug_id: 1
     ec50: 0.8
-  - pattern: "||||YY1||K....,.||||||..........|."
+  - pattern: "||||YY1||K....,.||||||............|."
     drug_id: 1
     ec50: 0.67
-  - pattern: "||||NF1||K....,.||||||..........|."
+  - pattern: "||||NF1||K....,.||||||............|."
     drug_id: 1
     ec50: 0.9
-  - pattern: "||||YF1||K....,.||||||..........|."
+  - pattern: "||||YF1||K....,.||||||............|."
     drug_id: 1
     ec50: 0.8
-  - pattern: "||||NY2||K....,.||||||..........|."
+  - pattern: "||||NY2||K....,.||||||............|."
     drug_id: 1
     ec50: 1.0
-  - pattern: "||||YY2||K....,.||||||..........|."
+  - pattern: "||||YY2||K....,.||||||............|."
     drug_id: 1
     ec50: 0.87
-  - pattern: "||||NF2||K....,.||||||..........|."
+  - pattern: "||||NF2||K....,.||||||............|."
     drug_id: 1
     ec50: 1.1
-  - pattern: "||||YF2||K....,.||||||..........|."
+  - pattern: "||||YF2||K....,.||||||............|."
     drug_id: 1
     ec50: 1.0
-  - pattern: "||||NY1||T....,.||||||..........|."
+  - pattern: "||||NY1||T....,.||||||............|."
     drug_id: 1
     ec50: 0.75
-  - pattern: "||||YY1||T....,.||||||..........|."
+  - pattern: "||||YY1||T....,.||||||............|."
     drug_id: 1
     ec50: 0.6
-  - pattern: "||||NF1||T....,.||||||..........|."
+  - pattern: "||||NF1||T....,.||||||............|."
     drug_id: 1
     ec50: 0.85
-  - pattern: "||||YF1||T....,.||||||..........|."
+  - pattern: "||||YF1||T....,.||||||............|."
     drug_id: 1
     ec50: 0.75
-  - pattern: "||||NY2||T....,.||||||..........|."
+  - pattern: "||||NY2||T....,.||||||............|."
     drug_id: 1
     ec50: 0.95
-  - pattern: "||||YY2||T....,.||||||..........|."
+  - pattern: "||||YY2||T....,.||||||............|."
     drug_id: 1
     ec50: 0.8
-  - pattern: "||||NF2||T....,.||||||..........|."
+  - pattern: "||||NF2||T....,.||||||............|."
     drug_id: 1
     ec50: 1.05
-  - pattern: "||||YF2||T....,.||||||..........|."
+  - pattern: "||||YF2||T....,.||||||............|."
     drug_id: 1
     ec50: 0.95
-  - pattern: "||||NY.||K....,.||||||..........|."
+  - pattern: "||||NY.||K....,.||||||............|."
     drug_id: 2
     ec50: 0.62
-  - pattern: "||||YY.||K....,.||||||..........|."
+  - pattern: "||||YY.||K....,.||||||............|."
     drug_id: 2
     ec50: 0.85
-  - pattern: "||||NF.||K....,.||||||..........|."
+  - pattern: "||||NF.||K....,.||||||............|."
     drug_id: 2
     ec50: 0.5
-  - pattern: "||||YF.||K....,.||||||..........|."
+  - pattern: "||||YF.||K....,.||||||............|."
     drug_id: 2
     ec50: 0.775
-  - pattern: "||||NY.||T....,.||||||..........|."
+  - pattern: "||||NY.||T....,.||||||............|."
     drug_id: 2
     ec50: 0.7
-  - pattern: "||||YY.||T....,.||||||..........|."
+  - pattern: "||||YY.||T....,.||||||............|."
     drug_id: 2
     ec50: 0.9
-  - pattern: "||||NF.||T....,.||||||..........|."
+  - pattern: "||||NF.||T....,.||||||............|."
     drug_id: 2
     ec50: 0.65
-  - pattern: "||||YF.||T....,.||||||..........|."
+  - pattern: "||||YF.||T....,.||||||............|."
     drug_id: 2
     ec50: 0.82
 
@@ -415,9 +426,10 @@ initial_parasite_info:
   #if location id is -1 all location will have the same initial parasites
   - location_id: -1
     parasite_info:
-      - aa_sequence: "||||NY1||KTHFI,x||||||FNMYRIPRPC|1"
+      #TNY__C1x
+      - aa_sequence: "||||NY1||KTHFI,x||||||FNCMYRIPRPCA|1"
         prevalence: 0.05
-      - aa_sequence: "||||YY1||KTHFI,x||||||FNMYRIPRPC|1"
+      - aa_sequence: "||||NY1||KTHFI,x||||||FNCMYRIPRPCA|1"
         prevalence: 0.05
 
 # drug information below
@@ -653,7 +665,7 @@ min_dosing_days: 1
 # exponentially distributed biting rate
 relative_bitting_info:
   max_relative_biting_value: 35
-  min_relative_biting_value: 0.35
+  min_relative_biting_value: 1.0
   number_of_biting_levels: 100
   biting_level_distribution:
     #  distribution: Exponential

--- a/src/Core/Config/Config.h
+++ b/src/Core/Config/Config.h
@@ -112,6 +112,8 @@ public:
 
   CONFIG_ITEM(within_host_induced_free_recombination, bool, true)
 
+  CONFIG_ITEM(mutation_probability_by_locus, double, 0)
+
   CUSTOM_CONFIG_ITEM(start_of_comparison_period, 0)
 
   CUSTOM_CONFIG_ITEM(number_of_age_classes, 0)

--- a/src/Core/Config/CustomConfigItem.cpp
+++ b/src/Core/Config/CustomConfigItem.cpp
@@ -183,7 +183,6 @@ void drug_db::set_value(const YAML::Node &node) {
       }
     }
 
-    dt->set_p_mutation(dt_node["mutation_probability"].as<double>());
     dt->set_k(dt_node["k"].as<double>());
 
     dt->base_EC50 = dt_node["base_EC50"].as<double>();

--- a/src/Events/Population/ChangeStrategyEvent.cpp
+++ b/src/Events/Population/ChangeStrategyEvent.cpp
@@ -9,5 +9,5 @@ ChangeStrategyEvent::ChangeStrategyEvent(const int &at_time, const int &strategy
 
 void ChangeStrategyEvent::execute() {
   Model::MODEL->set_treatment_strategy(strategy_id);
-  LOG(INFO) << date::year_month_day{scheduler->calendar_date} << " : switch to " << Model::TREATMENT_STRATEGY->name;
+  LOG(INFO) << date::year_month_day{scheduler->calendar_date} << ": switch to " << Model::TREATMENT_STRATEGY->name;
 }

--- a/src/Events/Population/PopulationEventBuilder.cpp
+++ b/src/Events/Population/PopulationEventBuilder.cpp
@@ -193,11 +193,9 @@ std::vector<Event*> PopulationEventBuilder::build_turn_on_mutation_event(const Y
     const auto starting_date = event_node["day"].as<date::year_month_day>();
     auto time = (date::sys_days { starting_date } - date::sys_days { config->starting_date() }).count();
     double mutation_probability = event_node["mutation_probability"] ? event_node["mutation_probability"].as<double>()
-                                                                     : Model::CONFIG->drug_db()->at(0)->p_mutation();
+                                                                     : Model::CONFIG->mutation_probability_by_locus();
 
-    int drug_id = event_node["drug_id"] ? event_node["drug_id"].as<int>() : -1;
-
-    auto* e = new TurnOnMutationEvent(time, mutation_probability, drug_id);
+    auto* e = new TurnOnMutationEvent(time, mutation_probability);
     events.push_back(e);
   }
 

--- a/src/Events/Population/TurnOffMutationEvent.cpp
+++ b/src/Events/Population/TurnOffMutationEvent.cpp
@@ -9,8 +9,6 @@ TurnOffMutationEvent::TurnOffMutationEvent(const int &at_time) {
 }
 
 void TurnOffMutationEvent::execute() {
-  for (auto &it : *Model::CONFIG->drug_db()) {
-    it.second->p_mutation() = 0.0;
-  }
+  Model::CONFIG->mutation_probability_by_locus() = 0.0;
   LOG(INFO) << date::year_month_day{scheduler->calendar_date} << " : turn mutation off";
 }

--- a/src/Events/Population/TurnOnMutationEvent.cpp
+++ b/src/Events/Population/TurnOnMutationEvent.cpp
@@ -4,17 +4,12 @@
 #include "Model.h"
 #include "Core/Config/Config.h"
 
-TurnOnMutationEvent::TurnOnMutationEvent(const int &at_time, const double &mutation_probability, const int &drug_id) :
-  mutation_probability{mutation_probability}, drug_id{drug_id} {
+TurnOnMutationEvent::TurnOnMutationEvent(const int &at_time, const double &mutation_probability) :
+  mutation_probability{mutation_probability} {
   time = at_time;
 }
 
 void TurnOnMutationEvent::execute() {
-  for (auto &it : *Model::CONFIG->drug_db()) {
-    if (it.second->id() == drug_id || drug_id == -1) {
-      it.second->p_mutation() = mutation_probability;
-    }
-  }
-
+  Model::CONFIG->mutation_probability_by_locus() = mutation_probability;
   LOG(INFO) << date::year_month_day{scheduler->calendar_date} << " : turn mutation on";
 }

--- a/src/Events/Population/TurnOnMutationEvent.h
+++ b/src/Events/Population/TurnOnMutationEvent.h
@@ -14,7 +14,7 @@ DISALLOW_MOVE(TurnOnMutationEvent)
   int drug_id = -1;
 
 public:
-  explicit TurnOnMutationEvent(const int &at_time, const double &mutation_probability, const int& drug_id);
+  explicit TurnOnMutationEvent(const int &at_time, const double &mutation_probability);
 
   ~TurnOnMutationEvent() override = default;
 

--- a/src/Events/ProgressToClinicalEvent.cpp
+++ b/src/Events/ProgressToClinicalEvent.cpp
@@ -73,7 +73,7 @@ void ProgressToClinicalEvent::execute() {
   const auto p_treatment = Model::TREATMENT_COVERAGE->get_probability_to_be_treated(
       person->location(), person->age());
 
-  // std::cout << p_treatment << std::endl;
+//   std::cout << p_treatment << std::endl;
   if (p <= p_treatment) {
     auto *therapy = Model::TREATMENT_STRATEGY->get_therapy(person);
 

--- a/src/MDC/ModelDataCollector.cpp
+++ b/src/MDC/ModelDataCollector.cpp
@@ -62,6 +62,18 @@ void ModelDataCollector::initialize() {
             Model::CONFIG->number_of_age_classes(),
             0.0
         ));
+    blood_slide_prevalence_by_location_age_ = DoubleVector2(
+          Model::CONFIG->number_of_locations(),
+          DoubleVector(
+                  80,
+                  0.0
+          ));
+    blood_slide_number_by_location_age_ = DoubleVector2(
+          Model::CONFIG->number_of_locations(),
+          DoubleVector(
+                  80,
+                  0.0
+          ));
     blood_slide_number_by_location_age_group_by_5_ = DoubleVector2(
         Model::CONFIG->number_of_locations(),
         DoubleVector(
@@ -289,6 +301,10 @@ void ModelDataCollector::perform_population_statistic() {
       blood_slide_number_by_location_age_group_by_5_[location][ac] = 0.0;
     }
     for (auto age = 0; age < 80; age++) {
+        blood_slide_prevalence_by_location_age_[location][age] = 0.0;
+        blood_slide_number_by_location_age_[location][age] = 0.0;
+    }
+    for (auto age = 0; age < 80; age++) {
       popsize_by_location_age_[location][age] = 0;
     }
 
@@ -332,6 +348,11 @@ void ModelDataCollector::perform_population_statistic() {
               blood_slide_prevalence_by_location_[loc] += 1;
               blood_slide_number_by_location_age_group_[loc][ac] += 1;
               blood_slide_number_by_location_age_group_by_5_[loc][ac1] += 1;
+              if (p->age() < 79) {
+                blood_slide_number_by_location_age_[loc][p->age()] += 1;
+              } else {
+                blood_slide_number_by_location_age_[loc][79] += 1;
+              }
             }
           } else if (hs == Person::CLINICAL) {
             number_of_positive_by_location_[loc]++;
@@ -341,10 +362,14 @@ void ModelDataCollector::perform_population_statistic() {
             blood_slide_number_by_location_age_group_by_5_[loc][ac1] += 1;
             number_of_clinical_by_location_age_group_[loc][ac] += 1;
             number_of_clinical_by_location_age_group_by_5_[loc][ac1] += 1;
+            if (p->age() < 79) {
+              blood_slide_number_by_location_age_[loc][p->age()] += 1;
+            } else {
+              blood_slide_number_by_location_age_[loc][79] += 1;
+            }
           }
 
           int moi = p->all_clonal_parasite_populations()->size();
-
 
           if (moi >= number_of_reported_MOI) {
             multiple_of_infection_by_location_[loc][number_of_reported_MOI - 1]++;
@@ -417,9 +442,15 @@ void ModelDataCollector::perform_population_statistic() {
       blood_slide_prevalence_by_location_age_group_[loc][ac] =
           blood_slide_number_by_location_age_group_[loc][ac] /
           static_cast<double>(popsize_by_location_age_class_[loc][ac]);
+
       blood_slide_prevalence_by_location_age_group_by_5_[loc][ac] =
           blood_slide_number_by_location_age_group_by_5_[loc][ac] /
           static_cast<double>(popsize_by_location_age_class_by_5_[loc][ac]);
+    }
+    for(int age = 0; age < 80; age++){
+        blood_slide_prevalence_by_location_age_[loc][age] =
+        blood_slide_number_by_location_age_[loc][age] /
+        static_cast<double>(popsize_by_location_age_[loc][age]);
     }
   }
 }

--- a/src/MDC/ModelDataCollector.h
+++ b/src/MDC/ModelDataCollector.h
@@ -52,6 +52,10 @@ PROPERTY_REF(DoubleVector2, blood_slide_number_by_location_age_group_by_5)
 
 PROPERTY_REF(DoubleVector2, blood_slide_prevalence_by_location_age_group_by_5)
 
+PROPERTY_REF(DoubleVector2, blood_slide_prevalence_by_location_age)
+
+PROPERTY_REF(DoubleVector2, blood_slide_number_by_location_age)
+
 PROPERTY_REF(DoubleVector, fraction_of_positive_that_are_clinical_by_location)
 
 PROPERTY_REF(LongVector, total_number_of_bites_by_location)

--- a/src/Parasites/Genotype.cpp
+++ b/src/Parasites/Genotype.cpp
@@ -196,17 +196,15 @@ void Genotype::calculate_EC50_power_n(const PfGeneInfo &gene_info, DrugDatabase 
   }
 }
 
-Genotype *Genotype::perform_mutation_by_drug(Config *pConfig, Random *pRandom, DrugType *pDrugType, double mutation_probability) const {
+Genotype *Genotype::perform_mutation_by_drug(Config *pConfig, Random *pRandom, DrugType *pDrugType, double mutation_probability_by_locus) const {
   std::string new_aa_sequence { aa_sequence };
   for(int aa_pos_id = 0; aa_pos_id < pDrugType->resistant_aa_locations.size(); aa_pos_id++) {
     // get aa position info (aa index in aa string, is copy number)
     auto aa_pos = pDrugType->resistant_aa_locations[aa_pos_id];
     if(pConfig->mutation_mask()[aa_pos.aa_index_in_aa_string] == '1'){
-//        LOG(INFO) << "Drug: " << pDrugType->name() << " genotype: " << aa_sequence << " mutation pos: " << aa_pos.aa_index_in_aa_string << " is 1";
         const auto p = Model::RANDOM->random_flat(0.0, 1.0);
-        if (p < mutation_probability){
-//            LOG(INFO) << "\tDrug: " << pDrugType->name() << " genotype: " << aa_sequence << " mutation happened at aa_pos_id: " << aa_pos_id << " aa_pos: " << aa_pos.aa_index_in_aa_string;
-            if (aa_pos.is_copy_number) {
+        if (p < mutation_probability_by_locus){
+          if (aa_pos.is_copy_number) {
                 // increase or decrease by 1 step
                 auto old_copy_number = NumberHelpers::char_to_single_digit_number(aa_sequence[aa_pos.aa_index_in_aa_string]);
                 if (old_copy_number == 1) {
@@ -237,14 +235,10 @@ Genotype *Genotype::perform_mutation_by_drug(Config *pConfig, Random *pRandom, D
                     new_aa = aa_list[new_aa_id + 1];
                 }
                 new_aa_sequence[aa_pos.aa_index_in_aa_string] = new_aa;
-//                LOG(INFO) << aa_pos_id <<  " MUTATION: " << aa_pos.aa_index_in_aa_string << " " << old_aa << " -> " << new_aa;
             }
         }
     }
   }
-//  if(new_aa_sequence != aa_sequence){
-//      LOG(INFO) << "AFTER FOR LOOP new aa sequence: " << new_aa_sequence;
-//  }
   // get genotype pointer from gene database based on aa sequence
   return pConfig->genotype_db.get_genotype(new_aa_sequence, pConfig);
 }

--- a/src/Parasites/Genotype.h
+++ b/src/Parasites/Genotype.h
@@ -56,7 +56,7 @@ public:
 
   void calculate_EC50_power_n(const PfGeneInfo& info, DrugDatabase* pDatabase);
 
-  Genotype* perform_mutation_by_drug(Config* pConfig, Random* pRandom, DrugType* pDrugType) const;
+  Genotype* perform_mutation_by_drug(Config* pConfig, Random* pRandom, DrugType* pDrugType, double mutation_probability) const;
 
   friend std::ostream& operator<<(std::ostream& os, const Genotype& e);
 

--- a/src/Parasites/Genotype.h
+++ b/src/Parasites/Genotype.h
@@ -56,7 +56,7 @@ public:
 
   void calculate_EC50_power_n(const PfGeneInfo& info, DrugDatabase* pDatabase);
 
-  Genotype* perform_mutation_by_drug(Config* pConfig, Random* pRandom, DrugType* pDrugType, double mutation_probability) const;
+  Genotype* perform_mutation_by_drug(Config* pConfig, Random* pRandom, DrugType* pDrugType, double mutation_probability_by_locus) const;
 
   friend std::ostream& operator<<(std::ostream& os, const Genotype& e);
 

--- a/src/Population/Population.cpp
+++ b/src/Population/Population.cpp
@@ -36,7 +36,6 @@ Population::Population(Model* model) : model_(model) {
 
   person_index_list_->push_back(all_persons_);
 }
-
 Population::~Population() {
   // release memory for all persons
   if (all_persons_ != nullptr) {
@@ -201,6 +200,8 @@ void Population::perform_infection_event() {
 
   today_infections.clear();
 }
+
+
 
 void Population::initialize() {
   if (model() != nullptr) {

--- a/src/Population/SingleHostClonalParasitePopulations.cpp
+++ b/src/Population/SingleHostClonalParasitePopulations.cpp
@@ -141,30 +141,25 @@ void SingleHostClonalParasitePopulations::update_by_drugs(DrugsInBlood* drugs_in
 
     double percent_parasite_remove = 0;
     for (auto& [drug_id, drug] : *drugs_in_blood->drugs()) {
-      const auto p = Model::RANDOM->random_flat(0.0, 1.0);
+      // select all locus
+      // remember to use mask to turn on and off mutation location
+      // for a specific time
+      Genotype* candidate_genotype = new_genotype->perform_mutation_by_drug(Model::CONFIG, Model::RANDOM, drug->drug_type(), drug->get_mutation_probability());
 
-      if (p < drug->get_mutation_probability()) {
-        // select all locus
-        // remember to use mask to turn on and off mutation location
-        // for a specific time
-        Genotype* candidate_genotype =
-            new_genotype->perform_mutation_by_drug(Model::CONFIG, Model::RANDOM, drug->drug_type());
-
-        if (candidate_genotype->get_EC50_power_n(drug->drug_type())
-            > new_genotype->get_EC50_power_n(drug->drug_type())) {
-          // higher EC50^n means lower efficacy then allow mutation occur
-          new_genotype = candidate_genotype;
-        }
-        if (new_genotype != blood_parasite->genotype()) {
-          // mutation occurs
-          Model::DATA_COLLECTOR->record_1_mutation(person_->location(), blood_parasite->genotype(), new_genotype);
-          //          LOG(TRACE) << Model::SCHEDULER->current_time() << "\t" << blood_parasite->genotype()->genotype_id
-          //          << "\t"
-          //                     << new_genotype->genotype_id << "\t"
-          //                     << blood_parasite->genotype()->get_EC50_power_n(drug->drug_type()) << "\t"
-          //                     << new_genotype->get_EC50_power_n(drug->drug_type());
-          blood_parasite->set_genotype(new_genotype);
-        }
+      if (candidate_genotype->get_EC50_power_n(drug->drug_type())
+          > new_genotype->get_EC50_power_n(drug->drug_type())) {
+        // higher EC50^n means lower efficacy then allow mutation occur
+        new_genotype = candidate_genotype;
+      }
+      if (new_genotype != blood_parasite->genotype()) {
+        // mutation occurs
+        Model::DATA_COLLECTOR->record_1_mutation(person_->location(), blood_parasite->genotype(), new_genotype);
+        //          LOG(TRACE) << Model::SCHEDULER->current_time() << "\t" << blood_parasite->genotype()->genotype_id
+        //          << "\t"
+        //                     << new_genotype->genotype_id << "\t"
+        //                     << blood_parasite->genotype()->get_EC50_power_n(drug->drug_type()) << "\t"
+        //                     << new_genotype->get_EC50_power_n(drug->drug_type());
+        blood_parasite->set_genotype(new_genotype);
       }
 
       const auto p_temp = drug->get_parasite_killing_rate(blood_parasite->genotype()->genotype_id);

--- a/src/Population/SingleHostClonalParasitePopulations.cpp
+++ b/src/Population/SingleHostClonalParasitePopulations.cpp
@@ -144,7 +144,8 @@ void SingleHostClonalParasitePopulations::update_by_drugs(DrugsInBlood* drugs_in
       // select all locus
       // remember to use mask to turn on and off mutation location
       // for a specific time
-      Genotype* candidate_genotype = new_genotype->perform_mutation_by_drug(Model::CONFIG, Model::RANDOM, drug->drug_type(), drug->get_mutation_probability());
+      Genotype* candidate_genotype = new_genotype->perform_mutation_by_drug(Model::CONFIG, Model::RANDOM, drug->drug_type(),
+                                                                            Model::CONFIG->mutation_probability_by_locus());
 
       if (candidate_genotype->get_EC50_power_n(drug->drug_type())
           > new_genotype->get_EC50_power_n(drug->drug_type())) {

--- a/src/Reporters/MonthlyReporter.cpp
+++ b/src/Reporters/MonthlyReporter.cpp
@@ -34,37 +34,41 @@ void MonthlyReporter::before_run() {}
 void MonthlyReporter::begin_time_step() {}
 
 void MonthlyReporter::monthly_report() {
-  std::stringstream ss;
+    std::stringstream ss;
 
-  ss << Model::SCHEDULER->current_time() << sep;
-  ss << std::chrono::system_clock::to_time_t(Model::SCHEDULER->calendar_date) << sep;
-  ss << date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date) << sep;
-  ss << Model::MODEL->get_seasonal_factor(Model::SCHEDULER->calendar_date, 0) << sep;
-  ss << Model::TREATMENT_COVERAGE->get_probability_to_be_treated(0, 1) << sep;
-  ss << Model::TREATMENT_COVERAGE->get_probability_to_be_treated(0, 10) << sep;
-  ss << Model::POPULATION->size() << sep;
-  ss << group_sep;
+    ss << Model::SCHEDULER->current_time() << sep;
+    ss << std::chrono::system_clock::to_time_t(Model::SCHEDULER->calendar_date) << sep;
+    ss << date::format("%Y\t%m\t%d", Model::SCHEDULER->calendar_date) << sep;
+    ss << Model::MODEL->get_seasonal_factor(Model::SCHEDULER->calendar_date, 0) << sep;
+    ss << Model::TREATMENT_COVERAGE->get_probability_to_be_treated(0, 1) << sep;
+    ss << Model::TREATMENT_COVERAGE->get_probability_to_be_treated(0, 10) << sep;
+    ss << Model::POPULATION->size() << sep;
+    ss << group_sep;
 
-  print_EIR_PfPR_by_location(ss);
-  ss << group_sep;
-  for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+    print_EIR_PfPR_by_location(ss);
+    ss << group_sep;
+    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
     ss << Model::DATA_COLLECTOR->monthly_number_of_new_infections_by_location()[loc] << sep;
-  }
-  ss << group_sep;
-  for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
-    ss << Model::DATA_COLLECTOR->monthly_number_of_treatment_by_location()[loc] << sep;
-  }
-  ss << group_sep;
-  for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
-    ss << Model::DATA_COLLECTOR->monthly_number_of_clinical_episode_by_location()[loc] << sep;
-  }
-  ss << group_sep;
-  for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
-    for(auto moi : Model::DATA_COLLECTOR->multiple_of_infection_by_location()[loc]){
-      ss << moi << sep;
     }
-  }
-  ss << group_sep;
+    ss << group_sep;
+    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+    ss << Model::DATA_COLLECTOR->monthly_number_of_treatment_by_location()[loc] << sep;
+    }
+    ss << group_sep;
+    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+    ss << Model::DATA_COLLECTOR->monthly_number_of_clinical_episode_by_location()[loc] << sep;
+    }
+    ss << group_sep;
+    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+        for(auto moi : Model::DATA_COLLECTOR->multiple_of_infection_by_location()[loc]){
+            ss << moi << sep;
+        }
+    }
+    ss << group_sep;
+    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+        ss << Model::DATA_COLLECTOR->cumulative_NTF_by_location()[loc] << sep;
+    }
+    ss << group_sep;
 
   // including total number of positive individuals
   //  ReporterUtils::output_genotype_frequency3(ss, Model::CONFIG->genotype_db.size(),

--- a/src/Reporters/MonthlyReporter.cpp
+++ b/src/Reporters/MonthlyReporter.cpp
@@ -60,12 +60,6 @@ void MonthlyReporter::monthly_report() {
     }
     ss << group_sep;
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
-        for(auto moi : Model::DATA_COLLECTOR->multiple_of_infection_by_location()[loc]){
-            ss << moi << sep;
-        }
-    }
-    ss << group_sep;
-    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         ss << Model::DATA_COLLECTOR->cumulative_NTF_by_location()[loc] << sep;
     }
     ss << group_sep;

--- a/src/Reporters/ReporterUtils.h
+++ b/src/Reporters/ReporterUtils.h
@@ -45,6 +45,19 @@ public:
       PersonIndexByLocationStateAgeClass* pi
   );
 
+  /// outputs genotype frequencies by the weighted number of parasite-positive individuals carrying genotype X / total number of
+    /// parasite-positive individuals (the weights for each person describe the fraction of their clonal
+    /// populations carrying genotype X; e.g. an individual host with five clonal infections two of which
+    /// carry genotype X would be given a weight of 2/5).
+    /// \param ss the output string stream
+    /// \param ss2 the output string stream - prmc
+    /// \param number_of_genotypes total number of genotypes defined in configuration
+    /// \param pi person index by location state and ageclass that obtained from the population object
+    static void output_genotype_frequency4(
+            std::stringstream& ss, std::stringstream& ss2, const int& number_of_genotypes,
+            PersonIndexByLocationStateAgeClass* pi
+    );
+
   /// \brief outputs genotype frequencies by all 3 methods:
   /// \details
   ///     1. number of parasite-positive individuals carrying genotype X / total number of parasite-positive

--- a/src/Reporters/ValidationReporter.cpp
+++ b/src/Reporters/ValidationReporter.cpp
@@ -154,6 +154,11 @@ void ValidationReporter::monthly_report() {
         }
     }
     ss << group_sep;//342
+    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+        ss << Model::DATA_COLLECTOR->cumulative_NTF_by_location()[loc] << sep;
+    }
+    ss << group_sep;
+
     monthly_data_file << ss.str() << std::endl;
 
     std::stringstream gene_freq_ss;

--- a/src/Reporters/ValidationReporter.cpp
+++ b/src/Reporters/ValidationReporter.cpp
@@ -23,10 +23,12 @@ ValidationReporter::ValidationReporter() = default;
 ValidationReporter::~ValidationReporter() = default;
 
 void ValidationReporter::initialize() {
-    gene_freq_file.open(fmt::format("{}/validation_gene_freq_{}.txt", Model::MODEL->output_path(), Model::MODEL->cluster_job_number()));
     monthly_data_file.open(fmt::format("{}/validation_monthly_data_{}.txt", Model::MODEL->output_path(), Model::MODEL->cluster_job_number()));
     summary_data_file.open(fmt::format("{}/validation_summary_{}.txt", Model::MODEL->output_path(), Model::MODEL->cluster_job_number()));
+    gene_freq_file.open(fmt::format("{}/validation_gene_freq_{}.txt", Model::MODEL->output_path(), Model::MODEL->cluster_job_number()));
     gene_db_file.open(fmt::format("{}/validation_gene_db_{}.txt", Model::MODEL->output_path(), Model::MODEL->cluster_job_number()));
+    prmc_freq_file.open(fmt::format("{}/validation_prmc_freq_{}.txt", Model::MODEL->output_path(), Model::MODEL->cluster_job_number()));
+    prmc_db_file.open(fmt::format("{}/validation_prmc_db_{}.txt", Model::MODEL->output_path(), Model::MODEL->cluster_job_number()));
 }
 
 void ValidationReporter::before_run() {}
@@ -155,10 +157,15 @@ void ValidationReporter::monthly_report() {
     monthly_data_file << ss.str() << std::endl;
 
     std::stringstream gene_freq_ss;
-    ReporterUtils::output_genotype_frequency3(gene_freq_ss, Model::CONFIG->genotype_db.size(),
+//    ReporterUtils::output_genotype_frequency3(gene_freq_ss, Model::CONFIG->genotype_db.size(),
+//                                              Model::POPULATION->get_person_index<PersonIndexByLocationStateAgeClass>());
+
+    std::stringstream prmc_freq_ss;
+    ReporterUtils::output_genotype_frequency4(gene_freq_ss, prmc_freq_ss, Model::CONFIG->genotype_db.size(),
                                               Model::POPULATION->get_person_index<PersonIndexByLocationStateAgeClass>());
 
     gene_freq_file << gene_freq_ss.str() << std::endl;
+    prmc_freq_file << prmc_freq_ss.str() << std::endl;
 }
 
 void ValidationReporter::after_run() {
@@ -213,12 +220,15 @@ void ValidationReporter::after_run() {
 
     for (auto [g_id, genotype] : Model::CONFIG->genotype_db) {
         gene_db_file << g_id << sep << genotype->aa_sequence << std::endl;
+        prmc_db_file << g_id << sep << genotype->aa_sequence << std::endl;
     }
 
+    gene_db_file.close();
     gene_freq_file.close();
+    prmc_db_file.close();
+    prmc_freq_file.close();
     monthly_data_file.close();
     summary_data_file.close();
-    gene_db_file.close();
 }
 
 void ValidationReporter::print_EIR_PfPR_by_location(std::stringstream& ss) {

--- a/src/Reporters/ValidationReporter.cpp
+++ b/src/Reporters/ValidationReporter.cpp
@@ -135,7 +135,17 @@ void ValidationReporter::monthly_report() {
         ss << Model::DATA_COLLECTOR->total_immune_by_location()[loc] / Model::POPULATION->size(loc) << sep;
     }
     ss << group_sep;//219
-
+    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+        int all_infected_pop = Model::DATA_COLLECTOR->popsize_by_location_hoststate()[loc][Person::ASYMPTOMATIC]
+                               + Model::DATA_COLLECTOR->popsize_by_location_hoststate()[loc][Person::CLINICAL];
+        if (all_infected_pop == 0){
+            ss << 0 << sep;
+        }
+        else{
+            ss << std::setprecision(6) << Model::DATA_COLLECTOR->monthly_number_of_clinical_episode_by_location()[loc] / (double) all_infected_pop<< sep;
+        }
+    }
+    ss << group_sep;//221
     monthly_data_file << ss.str() << std::endl;
 
     std::stringstream gene_freq_ss;
@@ -154,14 +164,12 @@ void ValidationReporter::after_run() {
     ss << Model::CONFIG->location_db()[0].population_size << sep;
     print_EIR_PfPR_by_location(ss);
 
-    ss << group_sep;//6
+    ss << group_sep;//10
     // output last strategy information
-    ss << Model::TREATMENT_STRATEGY->id << sep;
-
+    ss << Model::TREATMENT_STRATEGY->id << sep;//11
     // output NTF
     const auto total_time_in_years = (Model::SCHEDULER->current_time() - Model::CONFIG->start_of_comparison_period())
                                      / static_cast<double>(Constants::DAYS_IN_YEAR());
-
     auto sum_ntf = 0.0;
     ul pop_size = 0;
     for (auto location = 0; location < Model::CONFIG->number_of_locations(); location++) {
@@ -169,18 +177,17 @@ void ValidationReporter::after_run() {
         pop_size += Model::DATA_COLLECTOR->popsize_by_location()[location];
     }
     ss << (sum_ntf * 100 / pop_size) / total_time_in_years << sep;
-
-    ss << group_sep;//10
+    ss << group_sep;//13
     for (int location = 0; location < Model::CONFIG->number_of_locations(); location++) {
         ss << Model::DATA_COLLECTOR->cumulative_clinical_episodes_by_location()[location] << sep;
 //        std::cout << Model::DATA_COLLECTOR->cumulative_clinical_episodes_by_location()[location] << "\t";
     }
-    ss << group_sep;//12
+    ss << group_sep;//15
     for (int location = 0; location < Model::CONFIG->number_of_locations(); location++) {
         ss << Model::DATA_COLLECTOR->percentage_bites_on_top_20_by_location()[location] * 100 << "%"  << sep;
 //        std::cout << Model::DATA_COLLECTOR->percentage_bites_on_top_20_by_location()[location] * 100 << "%" << "\t";
     }
-    ss << group_sep;
+    ss << group_sep;//17
     for (int location = 0; location < Model::CONFIG->number_of_locations(); location++) {
         double location_NTF = Model::DATA_COLLECTOR->cumulative_NTF_by_location()[location] * 100 /
                               (double) Model::DATA_COLLECTOR->popsize_by_location()[location];
@@ -188,14 +195,14 @@ void ValidationReporter::after_run() {
         ss << location_NTF << sep;
 //        std::cout << location_NTF << "\t";
     }
-    ss << group_sep;//16
+    ss << group_sep;//19
     for (auto location = 0; location < Model::CONFIG->number_of_locations(); location++)
     {
         for (auto age = 0; age < 60; age++){
             ss << Model::DATA_COLLECTOR->cumulative_clinical_episodes_by_location_age()[location][age]/total_time_in_years/Model::DATA_COLLECTOR->popsize_by_location_age()[location][age] << sep;
         }
     }
-    ss << group_sep;
+    ss << group_sep;//80
 
     summary_data_file << ss.str() << std::endl;
 

--- a/src/Reporters/ValidationReporter.cpp
+++ b/src/Reporters/ValidationReporter.cpp
@@ -71,31 +71,37 @@ void ValidationReporter::monthly_report() {
     }
     ss << group_sep;//49
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
+        for (int age = 0; age < 80; age++){
+            ss << Model::DATA_COLLECTOR->blood_slide_prevalence_by_location_age()[loc][age] << sep;
+        }
+    }
+    ss << group_sep;///130
+    for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         ss << Model::DATA_COLLECTOR->current_TF_by_location()[loc] << sep;
     }
-    ss << group_sep;//51
+    ss << group_sep;//132
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         ss << Model::DATA_COLLECTOR->monthly_number_of_mutation_events_by_location()[loc] << sep;
     }
-    ss << group_sep;//53
+    ss << group_sep;//134
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         for (auto ac = 0ul; ac < Model::CONFIG->number_of_age_classes(); ac++){
             ss << Model::DATA_COLLECTOR->number_of_treatments_by_location_age_year()[loc][ac] << sep;
         }
     }
-    ss << group_sep;//69
+    ss << group_sep;//150
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         ss << Model::DATA_COLLECTOR->total_number_of_bites_by_location()[loc] << sep;
     }
-    ss << group_sep;//71
+    ss << group_sep;//152
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         ss << Model::DATA_COLLECTOR->total_number_of_bites_by_location_year()[loc] << sep;
     }
-    ss << group_sep;//73
+    ss << group_sep;//154
     ss << Model::DATA_COLLECTOR->number_of_treatments_with_therapy_ID()[0] << sep;
-    ss << group_sep;//75
+    ss << group_sep;//156
     ss << Model::DATA_COLLECTOR->number_of_treatments_fail_with_therapy_ID()[0] << sep;
-    ss << group_sep;//77
+    ss << group_sep;//158
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         if ((Model::DATA_COLLECTOR->popsize_by_location_hoststate()[loc][Person::ASYMPTOMATIC] + Model::DATA_COLLECTOR->popsize_by_location_hoststate()[loc][Person::CLINICAL]) == 0){
             ss << 0 << sep;
@@ -105,19 +111,19 @@ void ValidationReporter::monthly_report() {
                   (Model::DATA_COLLECTOR->popsize_by_location_hoststate()[loc][Person::ASYMPTOMATIC] + Model::DATA_COLLECTOR->popsize_by_location_hoststate()[loc][Person::CLINICAL])  << sep;
         }
     }
-    ss << group_sep;//79
+    ss << group_sep;//160
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
-        for (auto age = 0; age < 60; age++){
+        for (auto age = 0; age < 80; age++){
             ss << Model::DATA_COLLECTOR->popsize_by_location_age()[loc][age] << sep;
         }
     }
-    ss << group_sep;//140
+    ss << group_sep;//241
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
-        for (auto age = 0; age < 60; age++){
+        for (auto age = 0; age < 80; age++){
             ss << Model::DATA_COLLECTOR->monthly_number_of_clinical_episode_by_location_age()[loc][age] << sep;
         }
     }
-    ss << group_sep;//201
+    ss << group_sep;//322
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         for (auto ac = 0; ac < Model::CONFIG->number_of_age_classes(); ac++){
             int all_infected_pop = Model::DATA_COLLECTOR->popsize_by_location_hoststate_age_class()[loc][Person::ASYMPTOMATIC][ac]
@@ -130,11 +136,11 @@ void ValidationReporter::monthly_report() {
             }
         }
     }
-    ss << group_sep;//217
+    ss << group_sep;//338
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         ss << Model::DATA_COLLECTOR->total_immune_by_location()[loc] / Model::POPULATION->size(loc) << sep;
     }
-    ss << group_sep;//219
+    ss << group_sep;//340
     for (auto loc = 0; loc < Model::CONFIG->number_of_locations(); loc++) {
         int all_infected_pop = Model::DATA_COLLECTOR->popsize_by_location_hoststate()[loc][Person::ASYMPTOMATIC]
                                + Model::DATA_COLLECTOR->popsize_by_location_hoststate()[loc][Person::CLINICAL];
@@ -145,7 +151,7 @@ void ValidationReporter::monthly_report() {
             ss << std::setprecision(6) << Model::DATA_COLLECTOR->monthly_number_of_clinical_episode_by_location()[loc] / (double) all_infected_pop<< sep;
         }
     }
-    ss << group_sep;//221
+    ss << group_sep;//342
     monthly_data_file << ss.str() << std::endl;
 
     std::stringstream gene_freq_ss;
@@ -163,7 +169,6 @@ void ValidationReporter::after_run() {
     ss << Model::CONFIG->location_db()[0].beta << sep;
     ss << Model::CONFIG->location_db()[0].population_size << sep;
     print_EIR_PfPR_by_location(ss);
-
     ss << group_sep;//10
     // output last strategy information
     ss << Model::TREATMENT_STRATEGY->id << sep;//11
@@ -198,11 +203,11 @@ void ValidationReporter::after_run() {
     ss << group_sep;//19
     for (auto location = 0; location < Model::CONFIG->number_of_locations(); location++)
     {
-        for (auto age = 0; age < 60; age++){
+        for (auto age = 0; age < 80; age++){
             ss << Model::DATA_COLLECTOR->cumulative_clinical_episodes_by_location_age()[location][age]/total_time_in_years/Model::DATA_COLLECTOR->popsize_by_location_age()[location][age] << sep;
         }
     }
-    ss << group_sep;//80
+    ss << group_sep;//100
 
     summary_data_file << ss.str() << std::endl;
 

--- a/src/Reporters/ValidationReporter.h
+++ b/src/Reporters/ValidationReporter.h
@@ -17,10 +17,12 @@ class ValidationReporter : public Reporter {
 public:
     const std::string group_sep = "-1111\t";
     const std::string sep = "\t";
-    std::ofstream gene_freq_file;
     std::ofstream monthly_data_file;
     std::ofstream summary_data_file;
     std::ofstream gene_db_file;
+    std::ofstream gene_freq_file;
+    std::ofstream prmc_db_file;
+    std::ofstream prmc_freq_file;
 
 public:
     ValidationReporter();

--- a/src/Strategies/AdaptiveCyclingStrategy.cpp
+++ b/src/Strategies/AdaptiveCyclingStrategy.cpp
@@ -28,7 +28,7 @@ void AdaptiveCyclingStrategy::switch_therapy() {
 
   Model::DATA_COLLECTOR->update_UTL_vector();
   LOG(INFO) << date::year_month_day{Model::SCHEDULER->calendar_date}
-            << ": Cycling Strategy Swith Therapy to: " << therapy_list[index]->id();
+            << ": Adaptive Cycling Strategy switch Therapy to: " << therapy_list[index]->id();
 }
 
 Therapy *AdaptiveCyclingStrategy::get_therapy(Person *person) {
@@ -57,7 +57,7 @@ void AdaptiveCyclingStrategy::update_end_of_time_step() {
       if (Model::SCHEDULER->current_time() > latest_switch_time + turn_off_days) {
         latest_switch_time = Model::SCHEDULER->current_time() + delay_until_actual_trigger;
         LOG(INFO) << date::year_month_day{Model::SCHEDULER->calendar_date}
-                  << ": Adaptive Cyling will switch therapy next year";
+                  << ": Adaptive Cycling will switch therapy next year";
         //                    std::cout << "TF: " << Model::DATA_COLLECTOR->current_TF_by_therapy()[get_therapy()->id()] << std::endl;
       }
     }

--- a/src/Strategies/CyclingStrategy.cpp
+++ b/src/Strategies/CyclingStrategy.cpp
@@ -31,7 +31,7 @@ void CyclingStrategy::switch_therapy() {
   // TODO: cycling_time should be match with calendar day
   next_switching_day = Model::SCHEDULER->current_time() + cycling_time;
   LOG(INFO) << date::year_month_day{Model::SCHEDULER->calendar_date}
-            << ": Cycling Strategy Swith Therapy to: " << therapy_list[index]->id();
+            << ": Cycling Strategy switch therapy to: " << therapy_list[index]->id();
 }
 
 Therapy *CyclingStrategy::get_therapy(Person *person) {

--- a/src/Therapies/Drug.cpp
+++ b/src/Therapies/Drug.cpp
@@ -70,14 +70,15 @@ double Drug::get_current_drug_concentration(int currentTime) {
 
 double Drug::get_mutation_probability(double currentDrugConcentration) const {
   double P = 0;
+  double mutation_prob_by_locus = Model::CONFIG->mutation_probability_by_locus();
   if (currentDrugConcentration <= 0) return 0;
   if (currentDrugConcentration < (0.5))
-    P = 2 * drug_type_->p_mutation() * drug_type_->k() * currentDrugConcentration;
+    P = 2 * mutation_prob_by_locus * drug_type_->k() * currentDrugConcentration;
 
   else if (currentDrugConcentration >= (0.5) && currentDrugConcentration < 1.0) {
-    P = drug_type_->p_mutation() * (2 * (1 - drug_type_->k()) * currentDrugConcentration + (2 * drug_type_->k() - 1));
+    P = mutation_prob_by_locus * (2 * (1 - drug_type_->k()) * currentDrugConcentration + (2 * drug_type_->k() - 1));
   } else if (currentDrugConcentration >= 1.0) {
-    P = drug_type_->p_mutation();
+    P = mutation_prob_by_locus;
   }
   //    cout << P << endl;
   return P;

--- a/src/Therapies/DrugType.cpp
+++ b/src/Therapies/DrugType.cpp
@@ -23,7 +23,6 @@ DrugType::DrugType()
     : id_(0),
       drug_half_life_(0),
       maximum_parasite_killing_rate_(0),
-      p_mutation_(0),
       k_(0),
       cut_off_percent_(0),
       n_(1) {}

--- a/src/Therapies/DrugType.h
+++ b/src/Therapies/DrugType.h
@@ -38,8 +38,6 @@ public:
 
   VIRTUAL_PROPERTY_REF(DoubleVector, age_specific_drug_absorption);
 
-  VIRTUAL_PROPERTY_REF(double, p_mutation)
-
   VIRTUAL_PROPERTY_REF(double, k)
 
   VIRTUAL_PROPERTY_REF(double, cut_off_percent)

--- a/test/Core/Random/RouletteTest.cpp
+++ b/test/Core/Random/RouletteTest.cpp
@@ -4,6 +4,7 @@
 #include <fmt/format.h>
 
 #include <chrono>
+#include <numeric>
 
 #include "Core/Random.h"
 #include "Population/Person.h"
@@ -11,203 +12,219 @@
 
 class RouletteTest : public ::testing::Test {
 protected:
-  void SetUp() override {
-    r.initialize(0);
+    void SetUp() override {
+        r.initialize(0);
 
-    for (int i = 0; i < n_person; ++i) {
-      auto* p = new Person();
-      p->set_last_therapy_id(i);
-      all_person.push_back(p);
-      distribution.push_back(r.random_uniform());
-    }
-  }
-
-  void TearDown() override {
-    for (auto* p : all_person) {
-      delete p;
+        for (int i = 0; i < n_person; ++i) {
+            auto *p = new Person();
+            p->set_last_therapy_id(i);
+            all_person.push_back(p);
+            distribution.push_back(r.random_uniform());
+        }
     }
 
-    all_person.clear();
-    distribution.clear();
-  }
+    void TearDown() override {
+        for (auto *p: all_person) {
+            delete p;
+        }
 
-  Random r;
-  int n_sample { 10 };
-  int n_person { 1000 };
+        all_person.clear();
+        distribution.clear();
+    }
 
-  std::vector<Person*> all_person;
-  std::vector<double> distribution;
+    Random r;
+    int n_sample{10};
+    int n_person{1000};
+
+    std::vector<Person *> all_person;
+    std::vector<double> distribution;
 };
 
 TEST_F(RouletteTest, Sampling_with_sum_distribution_0) {
-  auto results = r.roulette_sampling<Person>(n_sample, distribution, all_person, false, 0);
+    auto results = r.roulette_sampling<Person>(n_sample, distribution, all_person, false, 0);
 
-  EXPECT_EQ(results.size(), n_sample);
-  EXPECT_EQ(results[0], nullptr);
+    EXPECT_EQ(results.size(), n_sample);
+    EXPECT_EQ(results[0], nullptr);
 }
 
 TEST_F(RouletteTest, Sampling_with_no_sum_distribution) {
-  std::vector<double> foi_distribution(n_person, 1.0);
+    std::vector<double> foi_distribution(n_person, 1.0);
 
-  // even id person will have no selection
-  for (int i = 0; i < n_person; i += 2) {
-    foi_distribution[i] = 0;
-  }
-  for (int n = 0; n < 10; ++n) {
-    auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, false);
-
-    EXPECT_EQ(results.size(), n_sample);
-
-    for (int i = 0; i < n_sample; ++i) {
-      std::cout << results[i]->last_therapy_id() << "\t";
-      EXPECT_EQ(results[i]->last_therapy_id() % 2, 1)
-          << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
+    // even id person will have no selection
+    for (int i = 0; i < n_person; i += 2) {
+        foi_distribution[i] = 0;
     }
-    std::cout << std::endl;
-  }
+    for (int n = 0; n < 10; ++n) {
+        auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, false);
+
+        EXPECT_EQ(results.size(), n_sample);
+
+        for (int i = 0; i < n_sample; ++i) {
+            std::cout << results[i]->last_therapy_id() << "\t";
+            EXPECT_EQ(results[i]->last_therapy_id() % 2, 1)
+                                << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
+        }
+        std::cout << std::endl;
+    }
 }
 
 TEST_F(RouletteTest, Sampling_with_one_in_all) {
-  std::vector<double> foi_distribution(n_person, 0.0);
+    std::vector<double> foi_distribution(n_person, 0.0);
 
-  foi_distribution[n_person - 1] = 1;
+    foi_distribution[n_person - 1] = 1;
 
-  for (int n = 0; n < 10; ++n) {
-    auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, false, 1);
+    for (int n = 0; n < 10; ++n) {
+        auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, false, 1);
 
-    EXPECT_EQ(results.size(), n_sample);
+        EXPECT_EQ(results.size(), n_sample);
 
-    for (int i = 0; i < n_sample; ++i) {
-      std::cout << results[i]->last_therapy_id() << "\t";
-      EXPECT_EQ(results[i]->last_therapy_id(), n_person - 1)
-          << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
+        for (int i = 0; i < n_sample; ++i) {
+            std::cout << results[i]->last_therapy_id() << "\t";
+            EXPECT_EQ(results[i]->last_therapy_id(), n_person - 1)
+                                << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
+        }
+        std::cout << std::endl;
     }
-    std::cout << std::endl;
-  }
 }
 
 TEST_F(RouletteTest, Sampling_with_2_in_all) {
-  std::vector<double> foi_distribution(n_person, 0.0);
+    std::vector<double> foi_distribution(n_person, 0.0);
 
-  foi_distribution[n_person - 1] = 0.2;
-  foi_distribution[0] = 1.8;
-  auto sum = foi_distribution[n_person - 1] + foi_distribution[0];
-  auto count { 0 }, n_repeat { 10 };
+    foi_distribution[n_person - 1] = 0.2;
+    foi_distribution[0] = 1.8;
+    auto sum = foi_distribution[n_person - 1] + foi_distribution[0];
+    auto count{0}, n_repeat{10};
 
-  for (int n = 0; n < n_repeat; ++n) {
-    auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, true);
+    for (int n = 0; n < n_repeat; ++n) {
+        auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, true);
 
-    EXPECT_EQ(results.size(), n_sample);
+        EXPECT_EQ(results.size(), n_sample);
 
-    for (int i = 0; i < n_sample; ++i) {
-      std::cout << results[i]->last_therapy_id() << "\t";
-      EXPECT_TRUE(results[i]->last_therapy_id() == (0) || results[i]->last_therapy_id() == (n_person - 1))
-          << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
-      if (results[i]->last_therapy_id() == (n_person - 1)) {
-        count++;
-      }
+        for (int i = 0; i < n_sample; ++i) {
+            std::cout << results[i]->last_therapy_id() << "\t";
+            EXPECT_TRUE(results[i]->last_therapy_id() == (0) || results[i]->last_therapy_id() == (n_person - 1))
+                                << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
+            if (results[i]->last_therapy_id() == (n_person - 1)) {
+                count++;
+            }
+        }
+        std::cout << std::endl;
     }
-    std::cout << std::endl;
-  }
 
-  std::cout << fmt::format("Expected - Actual freq: {} - {}", foi_distribution[n_person - 1] / sum,
-                           count / (double)(n_repeat * n_sample))
-            << std::endl;
-  //  EXPECT_NEAR(foi_distribution[n_person - 1] / sum, count / (double)(n_repeat * n_sample), 0.02);
+    std::cout << fmt::format("Expected - Actual freq: {} - {}", foi_distribution[n_person - 1] / sum,
+                             count / (double) (n_repeat * n_sample))
+              << std::endl;
+    //  EXPECT_NEAR(foi_distribution[n_person - 1] / sum, count / (double)(n_repeat * n_sample), 0.02);
 }
 
 TEST_F(RouletteTest, Sampling_with_4_in_all) {
-  std::vector<double> foi_distribution(n_person, 0.0);
+    std::vector<double> foi_distribution(n_person, 0.0);
 
-  foi_distribution[0] = 1;
-  foi_distribution[100] = 0.2;
-  foi_distribution[200] = 0.5;
-  foi_distribution[300] = 0.8;
+    foi_distribution[0] = 1;
+    foi_distribution[100] = 0.2;
+    foi_distribution[200] = 0.5;
+    foi_distribution[300] = 0.8;
 
-  auto sum = foi_distribution[0] + foi_distribution[100] + foi_distribution[200] + foi_distribution[300];
-  auto n_repeat { 10000 };
+    auto sum = foi_distribution[0] + foi_distribution[100] + foi_distribution[200] + foi_distribution[300];
+    auto n_repeat{10000};
 
-  std::map<int, int> count = {
-    { 0, 0 },
-    { 100, 0 },
-    { 200, 0 },
-    { 300, 0 },
-  };
+    std::map<int, int> count = {
+            {0,   0},
+            {100, 0},
+            {200, 0},
+            {300, 0},
+    };
 
-  for (int n = 0; n < n_repeat; ++n) {
-    auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, true, 2.5);
+    for (int n = 0; n < n_repeat; ++n) {
+        auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, true, 2.5);
 
-    EXPECT_EQ(results.size(), n_sample);
+        EXPECT_EQ(results.size(), n_sample);
 
-    for (int i = 0; i < n_sample; ++i) {
-      EXPECT_TRUE(results[i]->last_therapy_id() == 0 || results[i]->last_therapy_id() == 100
-                  || results[i]->last_therapy_id() == 200 || results[i]->last_therapy_id() == 300)
-          << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
-      count[results[i]->last_therapy_id()]++;
+        for (int i = 0; i < n_sample; ++i) {
+            EXPECT_TRUE(results[i]->last_therapy_id() == 0 || results[i]->last_therapy_id() == 100
+                        || results[i]->last_therapy_id() == 200 || results[i]->last_therapy_id() == 300)
+                                << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
+            count[results[i]->last_therapy_id()]++;
+        }
     }
-  }
 
-  std::cout << fmt::format("{} trials, {} samples per trial", n_repeat, n_sample) << std::endl;
-  for (const auto& [key, value] : count) {
-    std::cout << fmt::format("Key: {} \tExpected - Actual freq: {} - {}", key, foi_distribution[key] / sum,
-                             value / (double)(n_repeat * n_sample))
-              << std::endl;
-    EXPECT_NEAR(foi_distribution[key] / sum, value / (double)(n_repeat * n_sample), 0.01);
-  }
+    std::cout << fmt::format("{} trials, {} samples per trial", n_repeat, n_sample) << std::endl;
+    for (const auto &[key, value]: count) {
+        std::cout << fmt::format("Key: {} \tExpected - Actual freq: {} - {}", key, foi_distribution[key] / sum,
+                                 value / (double) (n_repeat * n_sample))
+                  << std::endl;
+        EXPECT_NEAR(foi_distribution[key] / sum, value / (double) (n_repeat * n_sample), 0.01);
+    }
 }
 
 TEST_F(RouletteTest, compare_with_multi_normial) {
-  std::vector<double> foi_distribution(n_person, 0.0);
-
-  foi_distribution[0] = 1;
-  foi_distribution[100] = 0.2;
-  foi_distribution[200] = 0.5;
-  foi_distribution[300] = 0.8;
-
-  auto sum = foi_distribution[0] + foi_distribution[100] + foi_distribution[200] + foi_distribution[300];
-  auto n_repeat { 10000 };
-
-  std::map<int, int> count = {
-    { 0, 0 },
-    { 100, 0 },
-    { 200, 0 },
-    { 300, 0 },
-  };
-  // ==================== roulette sampling ===========================
-  auto start = std::chrono::high_resolution_clock::now();
-  for (int n = 0; n < n_repeat; ++n) {
-    auto results = r.roulette_sampling<Person>(n_sample, foi_distribution, all_person, true, 2.5);
-
-    EXPECT_EQ(results.size(), n_sample);
-
-    for (int i = 0; i < n_sample; ++i) {
-      EXPECT_TRUE(results[i]->last_therapy_id() == 0 || results[i]->last_therapy_id() == 100
-                  || results[i]->last_therapy_id() == 200 || results[i]->last_therapy_id() == 300)
-          << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
-      count[results[i]->last_therapy_id()]++;
+    const auto size = 1000000;
+    std::vector<Person *> population;
+    population.reserve(size);
+    std::vector<double> foi_distribution;
+    foi_distribution.reserve(size);
+    for (int i = 0; i < size; ++i) {
+        auto *p = new Person();
+        p->set_last_therapy_id(i);
+        population.push_back(p);
+        foi_distribution.push_back(r.random_uniform());
     }
-  }
-  auto stop = std::chrono::high_resolution_clock::now();
-  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
 
-  std::cout << fmt::format("{} trials, {} samples per trial", n_repeat, n_sample) << std::endl;
-  std::cout << fmt::format("Roulette Sampling times: {}ms", duration.count()) << std::endl;
+    auto sum = std::accumulate(foi_distribution.begin(), foi_distribution.end(), 0.0);
+    auto n_repeat{10000};
+    const auto samples = 20000;
 
-  // ==================== multinomial sampling ===========================
-  start = std::chrono::high_resolution_clock::now();
-  for (int n = 0; n < n_repeat; ++n) {
-    auto results = r.multinomial_sampling<Person>(n_sample, foi_distribution, all_person, true, 2.5);
+//    std::map<int, int> count = {
+//            {0,   0},
+//            {100, 0},
+//            {200, 0},
+//            {300, 0},
+//    };
+    // ==================== roulette sampling ===========================
+    auto start = std::chrono::high_resolution_clock::now();
+    for (int n = 0; n < n_repeat; ++n) {
+        auto results = r.roulette_sampling<Person>(samples, foi_distribution, population, true);
 
-    EXPECT_EQ(results.size(), n_sample);
+        EXPECT_EQ(results.size(), samples);
 
-    for (int i = 0; i < n_sample; ++i) {
-      EXPECT_TRUE(results[i]->last_therapy_id() == 0 || results[i]->last_therapy_id() == 100
-                  || results[i]->last_therapy_id() == 200 || results[i]->last_therapy_id() == 300)
-          << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
-      count[results[i]->last_therapy_id()]++;
+//        for (int i = 0; i < n_sample; ++i) {
+//            EXPECT_TRUE(results[i]->last_therapy_id() == 0 || results[i]->last_therapy_id() == 100
+//                        || results[i]->last_therapy_id() == 200 || results[i]->last_therapy_id() == 300)
+//                                << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
+//            count[results[i]->last_therapy_id()]++;
+//        }
     }
-  }
-  stop = std::chrono::high_resolution_clock::now();
-  duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
-  std::cout << fmt::format("Multinomial Sampling times: {}ms", duration.count()) << std::endl;
+    auto stop = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
+
+    std::cout << fmt::format("{} trials, {} samples per trial", n_repeat, samples) << std::endl;
+    std::cout << fmt::format("Roulette Sampling times: {}ms", duration.count()) << std::endl;
+
+    // ==================== multinomial sampling ===========================
+    start = std::chrono::high_resolution_clock::now();
+    foi_distribution.resize(100);
+    for (int n = 0; n < n_repeat; ++n) {
+        auto results = r.multinomial_sampling<Person>(samples, foi_distribution, population, true, sum);
+
+        EXPECT_EQ(results.size(), samples);
+
+//        for (int i = 0; i < n_sample; ++i) {
+//            EXPECT_TRUE(results[i]->last_therapy_id() == 0 || results[i]->last_therapy_id() == 100
+//                        || results[i]->last_therapy_id() == 200 || results[i]->last_therapy_id() == 300)
+//                                << fmt::format("failed with p_id: {}", results[i]->last_therapy_id());
+//            count[results[i]->last_therapy_id()]++;
+//        }
+        for (int jj = 0; jj < samples; ++jj) {
+            r.random_uniform();
+        }
+    }
+    stop = std::chrono::high_resolution_clock::now();
+    duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
+
+    for (auto &p: population) {
+        delete p;
+    }
+
+    std::cout << fmt::format("Multinomial Sampling times: {}ms", duration.count()) << std::endl;
+
 }


### PR DESCRIPTION
Added mutation_probability_by_locus variable in config file. This variable is used to replace the mutation_probability in each drug in old model config file. Mutation events also utilize this variable to turn mutation on and off.